### PR TITLE
adding .travis.yml and appveyor.yml, badges on README for build logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: c
+compiler:
+  - gcc
+addons:
+  apt:
+    packages:
+    - build-essential
+    - pkg-config 
+    - cmake 
+    - libfreetype6-dev 
+    - libogg-dev 
+    - libtheora-dev 
+    - libvorbis-dev
+    - liballegro4-dev
+    - libaldmb1-dev
+script:
+- mkdir build-liballegro
+- cd build-liballegro
+- cmake -D SHARED=off -DCMAKE_BUILD_TYPE=Debug ..
+- make

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# lib-allegro
+The fork of the official Allegro repository. Mainly for applying AGS-specific patches.
+
+Windows build - Appveyor [![Build status](https://ci.appveyor.com/api/projects/status/lnhbccq3d7fkrxen/branch/allegro-4.4.2-agspatch?svg=true)](https://ci.appveyor.com/project/adventuregamestudio/lib-allegro/branch/allegro-4.4.2-agspatch) | 
+Linux build - Travis-Ci [![Build Status](https://travis-ci.com/adventuregamestudio/lib-allegro.svg?branch=allegro-4.4.2-agspatch)](https://travis-ci.com/adventuregamestudio/lib-allegro)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+version: "{build}"
+image: Visual Studio 2017
+platform:
+ - Win32
+
+configuration:
+ - Debug MD
+ - Debug MT
+ - Release MD
+ - Release MT
+
+branches:
+  only:
+    - allegro-4.4.2-agspatch
+
+before_build:
+  - ps: $Env:PLATFORM_TOOLSET="v141"
+
+build:
+  project: build/VS2015/ALLEGRO.sln
+  parallel: true
+  verbosity: minimal
+  
+artifacts:
+  - path: build\VS2015\lib\alleg-debug-static.lib
+    name: alleg-debug-static.lib
+  - path: build\VS2015\lib\alleg-debug-static-mt.lib
+    name: alleg-debug-static-mt.lib
+  - path: build\VS2015\lib\alleg-static.lib
+    name: alleg-static.lib
+  - path: build\VS2015\lib\alleg-static-mt.lib
+    name: alleg-static-mt.lib


### PR DESCRIPTION
Later it will still need modification to be able to push the binaries from lib-allegro to Releases, supposing AGS will want to pick already built Allegro library.

(I couldn't figure out how to merge commits and keep [the previous PR here](https://github.com/adventuregamestudio/lib-allegro/pull/1))

[Travis build link](https://github.com/ericoporto/lib-allegro/runs/34773733) | [AppVeyor build link](https://ci.appveyor.com/project/ericoporto/lib-allegro/builds/20550186)