### PR TITLE
adding deploy keys to allow releases to be generated from repository.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,13 @@ script:
 - cd build-liballegro
 - cmake -D SHARED=off -DCMAKE_BUILD_TYPE=Debug ..
 - make
+- tar -zcf lib-allegro.tar.gz include/ lib/
+deploy:
+  provider: releases
+  skip_cleanup: true
+  api_key: $GITHUB_TOKEN
+  file: build/lib-allegro.tar.gz
+  on:
+    repo: adventuregamestudio/lib-allegro
+    branch: allegro-4.4.2-agspatch
+    tags: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # lib-allegro
 The fork of the official Allegro repository. Mainly for applying AGS-specific patches.
 
-Windows build - Appveyor [![Build status](https://ci.appveyor.com/api/projects/status/lnhbccq3d7fkrxen/branch/allegro-4.4.2-agspatch?svg=true)](https://ci.appveyor.com/project/adventuregamestudio/lib-allegro/branch/allegro-4.4.2-agspatch) | 
+Windows build - Appveyor [![Build status](https://ci.appveyor.com/api/projects/status/24mb8sq5rxjfq11q/branch/allegro-4.4.2-agspatch?svg=true)](https://ci.appveyor.com/project/ags-ci-user/lib-allegro/branch/allegro-4.4.2-agspatch) | 
 Linux build - Travis-Ci [![Build Status](https://travis-ci.com/adventuregamestudio/lib-allegro.svg?branch=allegro-4.4.2-agspatch)](https://travis-ci.com/adventuregamestudio/lib-allegro)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,3 +30,14 @@ artifacts:
     name: alleg-static.lib
   - path: build\VS2015\lib\alleg-static-mt.lib
     name: alleg-static-mt.lib
+
+
+deploy:
+- provider: GitHub
+  auth_token:
+    secure: HovB+Z9gvI7LJtT4uoSk8W7WYGT9n1UJn14NKkg8EgdosS/Ba36tzP2LqIy42NFL
+  artifact: alleg-debug-static.lib, alleg-debug-static-mt.lib, alleg-static.lib, alleg-static-mt.lib
+  draft: false
+  on:
+    branch: allegro-4.4.2-agspatch # release from allegro-4.4.2-agspatch branch only
+    appveyor_repo_tag: true        # deploy on tag push only


### PR DESCRIPTION
actual deploy on the repo was not tested since it requires experimenting on the actual repo, but I think it should work.

The idea is that once this pull is accepted, creating a Release on the Github Repository, under Releases, will trigger a build on AppVeyor/Travis-CI and resulting artifacts are uploaded back to Github, annexed to the Release.

Also the badge for appveyor should be correct here in the updates on the README.