### PR TITLE
fix artifacts path on TravisCI yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ deploy:
   provider: releases
   skip_cleanup: true
   api_key: $GITHUB_TOKEN
-  file: build/lib-allegro.tar.gz
+  file: build-liballegro/lib-allegro.tar.gz
   on:
     repo: adventuregamestudio/lib-allegro
     branch: allegro-4.4.2-agspatch


### PR DESCRIPTION
the path to actually build liballegro was wrong on TravisCI, this is a fix.