### PR TITLE
Travis-CI: Modify build dependencies and settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: c
+
 compiler:
   - gcc
+
 addons:
   apt:
     packages:
@@ -8,12 +10,14 @@ addons:
       - libasound2-dev
       - libjack-dev
       - libsdl2-dev
+
 script:
-- mkdir build-liballegro
-- cd build-liballegro
-- cmake -DCMAKE_BUILD_TYPE=Debug ..
-- make
-- tar -zcf lib-allegro.tar.gz include/ lib/
+  - mkdir build-liballegro
+  - cd build-liballegro
+  - cmake -DCMAKE_BUILD_TYPE=Debug ..
+  - make
+  - tar -zcf lib-allegro.tar.gz include/ lib/
+
 deploy:
   provider: releases
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,34 @@ addons:
       - libjack-dev
       - libsdl2-dev
 
+env:
+  - BUILD_TYPE=debug
+    SHARED=on
+  - BUILD_TYPE=debug
+    SHARED=off
+  - BUILD_TYPE=release
+    SHARED=on
+  - BUILD_TYPE=release
+    SHARED=off
+
+before_script:
+  - |
+    filename=lib-allegro_$BUILD_TYPE
+    [ "$SHARED" = "off" ] && filename=${filename}_static
+    export filename
+
 script:
-  - mkdir build-liballegro
-  - cd build-liballegro
-  - cmake -DCMAKE_BUILD_TYPE=Debug ..
+  - mkdir build_$filename
+  - cd build_$filename
+  - cmake -DSHARED=$SHARED -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
   - make
-  - tar -zcf lib-allegro.tar.gz include/ lib/
+  - tar -cvzf $filename.tar.gz include/ lib/
 
 deploy:
   provider: releases
   skip_cleanup: true
   api_key: $GITHUB_TOKEN
-  file: lib-allegro.tar.gz
+  file_glob: true
+  file: lib-allegro_*.tar.gz
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,11 @@ compiler:
 addons:
   apt:
     packages:
-    - build-essential
-    - pkg-config 
-    - cmake 
-    - libfreetype6-dev 
-    - libogg-dev 
-    - libtheora-dev 
-    - libvorbis-dev
-    - liballegro4-dev
-    - libaldmb1-dev
+      - cmake
 script:
 - mkdir build-liballegro
 - cd build-liballegro
-- cmake -D SHARED=off -DCMAKE_BUILD_TYPE=Debug ..
+- cmake -DCMAKE_BUILD_TYPE=Debug ..
 - make
 - tar -zcf lib-allegro.tar.gz include/ lib/
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ addons:
   apt:
     packages:
       - cmake
+      - libasound2-dev
+      - libjack-dev
 script:
 - mkdir build-liballegro
 - cd build-liballegro

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
       - cmake
       - libasound2-dev
       - libjack-dev
+      - libsdl2-dev
 script:
 - mkdir build-liballegro
 - cd build-liballegro


### PR DESCRIPTION
- Remove AGS build dependencies
- `SHARED=off` is already specified in CMakeLists.txt

Also, as a side effect, test that AppVeyor gets notified about a PR.