### PR TITLE
Fix calling gfx_driver null function in set_palette_range

### DIFF
--- a/src/gfx.c
+++ b/src/gfx.c
@@ -239,7 +239,7 @@ void set_palette_range(AL_CONST PALETTE p, int from, int to, int vsync)
 
    _current_palette_changed = 0xFFFFFFFF & ~(1<<(_color_depth-1));
 
-   if (gfx_driver) {
+   if ((gfx_driver) && (gfx_driver->set_palette)) {
       if ((screen->vtable->color_depth == 8) && (!_dispsw_status))
 	 gfx_driver->set_palette(p, from, to, vsync);
    }


### PR DESCRIPTION
Some AGS games, such as Terror of the Vampire, crash at start on macOS when it is calling the allegro `set_palette_range`.

The call stack looks like this:
```
* thread #4, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x0000000000000000
    frame #1: 0x00000001003e6bf8 ags`set_palette_range(p=0x000000010051cd88, from=0, to=255, vsync=-1) at gfx.c:244:3
    frame #2: 0x00000001003e6c6c ags`set_palette(p=0x000000010051cd88) at gfx.c:218:4
    frame #3: 0x00000001003eca9c ags`_set_gfx_mode(card=1129268812, w=320, h=200, v_w=0, v_h=0, allow_config=-1) at graphics.c:826:4
    frame #4: 0x00000001003ebf10 ags`set_gfx_mode(card=1129268812, w=320, h=200, v_w=0, v_h=0) at graphics.c:611:14
    frame #5: 0x0000000100167268 ags`AGS::Engine::ALSW::ALSoftwareGraphicsDriver::SetDisplayMode(this=0x00000001138120d0, mode=0x000000016ff9e890) at ali3dsw.cpp:206:33
```

And more precisely:
```
frame #1: 0x00000001003e6bf8 ags`set_palette_range(p=0x000000010051cd88, from=0, to=255, vsync=-1) at gfx.c:244:3
   241 	
   242 	   if (gfx_driver) {
   243 	      if ((screen->vtable->color_depth == 8) && (!_dispsw_status))
-> 244 		 gfx_driver->set_palette(p, from, to, vsync);
   245 	   }
   246 	   else if ((system_driver) && (system_driver->set_palette_range))
   247 	      system_driver->set_palette_range(p, from, to, vsync);
```

The issue is that `gfx_driver->set_palette` is null. It seems to be normal for the gfx_driver to have null function pointers, and everywhere else where it is using a function from the `gfx_driver` it checks first that it is not null. So the obvious fix is to add a sanity check here as well.